### PR TITLE
Actually read commit, tag and branch values.

### DIFF
--- a/lib/r10kdiff.rb
+++ b/lib/r10kdiff.rb
@@ -25,11 +25,11 @@ module R10kDiff
   class PuppetModule
     def initialize(name, ref:nil, git:nil, forge:nil, tag:nil, commit:nil, branch:nil)
       @name = name
-      @ref = ref
+      @ref = tag || commit || branch || ref
       @git = git
       @forge = forge
     end
-    attr_reader :name, :ref, :tag, :commit, :branch
+    attr_reader :name, :ref
 
     def git?
       !!@git


### PR DESCRIPTION
@dcosson @phathocker 

PR https://github.com/dcosson/r10kdiff/pull/2 does not use the value of `tag`, `commit` or `branch`, it just accepts them and doesn't do anything, only `ref` worked.

This PR fixes that by actually using those values, and you don't need `tag`, `commit` or `branch` attr_reader since they are not being read outside the class.
