### PR TITLE
Account for missing Puppetfile `mod` options

### DIFF
--- a/lib/r10kdiff.rb
+++ b/lib/r10kdiff.rb
@@ -23,7 +23,7 @@ module R10kDiff
   end
 
   class PuppetModule
-    def initialize(name, ref:nil, git:nil, forge:nil, tag:nil, commit:nil, branch:nil)
+    def initialize(name, ref:nil, git:nil, forge:nil, tag:nil, commit:nil, branch:nil, install_path:nil, local:nil)
       @name = name
       @ref = ref
       @git = git


### PR DESCRIPTION
The `mod` method in a Puppetfile supports two additional parameters
which are not accounted for here: local, and install_path. This commit
does not do anything with the data, but it allows r10kdiff to parse files
that use these directives without raising an exception.